### PR TITLE
1.0.7

### DIFF
--- a/includes/class-kbs-cache-helper.php
+++ b/includes/class-kbs-cache-helper.php
@@ -49,7 +49,7 @@ class KBS_Cache_Helper {
 			return;
 		}
 
-        if ( 'article' == get_post_type() )    {
+        if ( 'article' == get_post_type() && kbs_article_is_restricted( get_the_ID() ) )    {
             self::nocache();
             return;
         }

--- a/includes/tickets/ticket-functions.php
+++ b/includes/tickets/ticket-functions.php
@@ -1206,7 +1206,12 @@ function kbs_get_reply_author_name( $reply, $role = false )	{
 	if ( ! empty( $reply->post_author ) ) {
 		$author      = get_userdata( $reply->post_author );
 		$author      = $author->display_name;
-		$author_role = __( 'Agent', 'kb-support' );
+
+        if ( kbs_is_agent( $reply->post_author ))   {
+            $author_role = __( 'Agent', 'kb-support' );
+        } else  {
+            $author_role = __( 'Customer', 'kb-support' );
+        }
 	} else {
 		$customer_id = get_post_meta( $reply->ID, '_kbs_reply_customer_id', true );
 		if ( $customer_id )	{


### PR DESCRIPTION
The caching of restricted articles can have result in visitors who
should have access being presented with a restriction message.
We’ve updated the cache helper class to cache any post that is of type
article and has restrictions