### PR TITLE
Attach inline images and documents for PlainText emails

### DIFF
--- a/includes/emails/email-functions.php
+++ b/includes/emails/email-functions.php
@@ -119,7 +119,7 @@ function kbs_email_ticket_reply( $ticket_id, $reply_id ) {
 
 	$message      = kbs_do_email_tags( kbs_get_ticket_reply_email_body_content( $ticket_id, $ticket_data ), $ticket_id );
 	$attachments  = apply_filters( 'kbs_ticket_reply_attachments', array(), $ticket_id, $ticket_data, $reply_id );
-error_log( 'att: ' . var_export( $attachments, true ) );
+
 	$emails       = KBS()->emails;
 
 	$emails->__set( 'from_name', $from_name );

--- a/includes/emails/email-functions.php
+++ b/includes/emails/email-functions.php
@@ -117,9 +117,9 @@ function kbs_email_ticket_reply( $ticket_id, $reply_id ) {
 	$heading      = apply_filters( 'kbs_ticket_reply_heading', $heading, $ticket_id, $ticket_data, $reply_id );
 	$heading      = kbs_do_email_tags( $heading, $ticket_id );
 
-	$attachments  = apply_filters( 'kbs_ticket_reply_attachments', array(), $ticket_id, $ticket_data, $reply_id );
 	$message      = kbs_do_email_tags( kbs_get_ticket_reply_email_body_content( $ticket_id, $ticket_data ), $ticket_id );
-
+	$attachments  = apply_filters( 'kbs_ticket_reply_attachments', array(), $ticket_id, $ticket_data, $reply_id );
+error_log( 'att: ' . var_export( $attachments, true ) );
 	$emails       = KBS()->emails;
 
 	$emails->__set( 'from_name', $from_name );

--- a/includes/emails/email-template.php
+++ b/includes/emails/email-template.php
@@ -14,13 +14,26 @@ if ( !defined( 'ABSPATH' ) )
 	exit;
 
 /**
+ * Retrieve the current email template.
+ *
+ * This is simply a wrapper to KBS_Email_Templates->get_template()
+ *
+ * @since	1.1.10
+ * return	str
+ */
+function kbs_get_email_template()	{
+	$template = new KBS_Emails;
+	return $template->get_template();
+} // kbs_get_email_template
+
+/**
  * Gets all the email templates that have been registerd. The list is extendable
  * and more templates can be added.
  *
  * This is simply a wrapper to KBS_Email_Templates->get_templates()
  *
  * @since	1.0
- * @return	arr		$templates	All the registered email templates
+ * @return	arr		All the registered email templates
  */
 function kbs_get_email_templates()   {
 	$templates = new KBS_Emails;

--- a/includes/files.php
+++ b/includes/files.php
@@ -336,7 +336,7 @@ function kbs_maybe_attach_files_to_email( $id ) {
 function kbs_get_attachments_from_inline_content( $id )	{
 
 	$attachments = false;
-	$content     = get_post_field( 'post_content', '338', 'raw' );
+	$content     = get_post_field( 'post_content', $id, 'raw' );
 
 	if ( ! empty( $content ) )	{
 
@@ -364,7 +364,7 @@ function kbs_get_attachments_from_inline_content( $id )	{
 
 	return $attachments;
 } // kbs_get_attachments_from_inline_content
-add_action('init', 'kbs_get_attachments_from_inline_content' );
+add_action( 'init', 'kbs_get_attachments_from_inline_content' );
 
 /**
  * Retrieve an attachment's full path from its URL.

--- a/includes/files.php
+++ b/includes/files.php
@@ -298,7 +298,7 @@ function kbs_maybe_attach_files_to_email( $id ) {
 
 			$files = kbs_get_attachments_from_inline_content( $id );
 
-			if ( $files )	{
+			if ( ! empty( $files ) )	{
 				$attachments = $files;
 			}
 
@@ -308,7 +308,7 @@ function kbs_maybe_attach_files_to_email( $id ) {
 
 			if ( $files )   {
 				foreach ( $files as $file ) {
-					$attachments[] =  get_attached_file( $file->ID );
+					$attachments[] = get_attached_file( $file->ID );
 				}
 			}
 
@@ -331,11 +331,11 @@ function kbs_maybe_attach_files_to_email( $id ) {
  *
  * @since	1.1.10
  * @param	int			$id		Ticket or Reply ID
- * @return	bool|arr	false or an array of files to attach
+ * @return	arr			Array of files to attach
  */
 function kbs_get_attachments_from_inline_content( $id )	{
 
-	$attachments = false;
+	$attachments = array();
 	$content     = get_post_field( 'post_content', $id, 'raw' );
 
 	if ( ! empty( $content ) )	{
@@ -364,7 +364,6 @@ function kbs_get_attachments_from_inline_content( $id )	{
 
 	return $attachments;
 } // kbs_get_attachments_from_inline_content
-add_action( 'init', 'kbs_get_attachments_from_inline_content' );
 
 /**
  * Retrieve an attachment's full path from its URL.
@@ -410,6 +409,7 @@ function kbs_get_attachment_path_from_url( $url )	{
 
 					if ( $original_file === $file || in_array( $file, $cropped_image_files ) ) {
 						$file_path = $meta['file'];
+						$file_path = trailingslashit( WP_CONTENT_DIR ) . $file_path;
 						return $file_path;
 					}
 

--- a/includes/files.php
+++ b/includes/files.php
@@ -388,11 +388,17 @@ function kbs_get_attachment_path_from_url( $url )	{
 				'post_status' => 'inherit',
 				'fields'      => 'ids',
 				'meta_query'  => array(
+					'relation' => 'OR',
 					array(
 						'value'   => $file,
 						'compare' => 'LIKE',
 						'key'     => '_wp_attachment_metadata',
 					),
+					array(
+						'value'   => $file,
+						'compare' => 'LIKE',
+						'key'     => '_wp_attached_file',
+					)
 				)
 			);
 
@@ -404,8 +410,13 @@ function kbs_get_attachment_path_from_url( $url )	{
 
 					$meta = wp_get_attachment_metadata( $post_id );
 
-					$original_file       = basename( $meta['file'] );
-					$cropped_image_files = wp_list_pluck( $meta['sizes'], 'file' );
+					if ( $meta )	{
+						$original_file       = basename( $meta['file'] );
+						$cropped_image_files = wp_list_pluck( $meta['sizes'], 'file' );
+					} else	{
+						$original_file       = basename( get_attached_file( $post_id ) );
+						$cropped_image_files = array();
+					}
 
 					if ( $original_file === $file || in_array( $file, $cropped_image_files ) ) {
 						$file_path = $original_file;

--- a/includes/files.php
+++ b/includes/files.php
@@ -408,8 +408,8 @@ function kbs_get_attachment_path_from_url( $url )	{
 					$cropped_image_files = wp_list_pluck( $meta['sizes'], 'file' );
 
 					if ( $original_file === $file || in_array( $file, $cropped_image_files ) ) {
-						$file_path = $meta['file'];
-						$file_path = trailingslashit( WP_CONTENT_DIR ) . $file_path;
+						$file_path = $original_file;
+						$file_path = trailingslashit( $upload_dir['path'] ) . $file_path;
 						return $file_path;
 					}
 


### PR DESCRIPTION
Scan admin ticket and reply content for inline images and files when sending PlainText emails and include them as email attachments. Fixes #77 