### PR TITLE
Feature/reply auto refresh

### DIFF
--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -335,6 +335,35 @@ jQuery(document).ready(function ($) {
 
 		reply : function() {
 
+            // Listen for new replies via WP heartbeat
+            if( kbs_vars.editing_ticket === '1' )   {
+                $( document ).on( 'heartbeat-send', function ( event, data ) {
+
+                    var kbs_last_reply = $( '#kbs-latest-reply' ).val();
+
+                    if ( kbs_last_reply === '0' )   {
+                        return;
+                    }
+
+                    data.kbs_last_reply = kbs_last_reply;
+                    data.kbs_ticket_id  = kbs_vars.post_id;
+                });
+
+                // Check for data on heartbeat reply and process
+                $( document ).on( 'heartbeat-tick', function ( event, data ) {
+
+                    if ( ! data.has_new_reply ) {
+                        return;
+                    }
+
+                    $( '#kbs-latest-reply' ).val(data.has_new_reply);
+                    if ( confirm( kbs_vars.new_reply_notice ) ) {
+                        $('.kbs-historic-reply-option-fields').empty();
+                        kbs_load_ticket_replies( kbs_vars.post_id, 0, 1 );
+                    }
+                });
+            }
+
             // Delete a reply
             $( document.body ).on( 'click', '.reply-delete', function(event) {
                 event.preventDefault();

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -258,9 +258,14 @@ function kbs_ajax_display_ticket_replies()	{
 
 		$replies_query = new KBS_Replies_Query( $args );
 		$replies       = $replies_query->get_replies();
+        $latest_reply  = false;
 
 		if ( ! empty( $replies ) )	{
 			foreach( $replies as $reply )	{
+                if ( ! $latest_reply )  {
+                    $output .= sprintf( '<input type="hidden" name="kbs_latest_reply" value="%s">', $reply->ID );
+                    $latest_reply = true;
+                }
                 $output .= '<div class="kbs_historic_replies_wrapper">';
                     $output .= kbs_get_reply_html( $reply, $_POST['kbs_ticket_id'] );
                 $output .= '</div>';

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -263,7 +263,7 @@ function kbs_ajax_display_ticket_replies()	{
 		if ( ! empty( $replies ) )	{
 			foreach( $replies as $reply )	{
                 if ( ! $latest_reply )  {
-                    $output .= sprintf( '<input type="hidden" name="kbs_latest_reply" value="%s">', $reply->ID );
+                    $output .= sprintf( '<input type="hidden" id="kbs-latest-reply" name="kbs_latest_reply" value="%s">', $reply->ID );
                     $latest_reply = true;
                 }
                 $output .= '<div class="kbs_historic_replies_wrapper">';
@@ -280,7 +280,9 @@ function kbs_ajax_display_ticket_replies()	{
 				);
 			}
 
-		}
+		} else    {
+            $output .= '<input type="hidden" id="kbs-latest-reply" name="kbs_latest_reply" value="0">';
+        }
 
 	}
 

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -118,7 +118,6 @@ function kbs_register_styles() {
     $is_submission = kbs_is_submission_form();
     $shortcodes    = array( 'kbs_tickets', 'kbs_login', 'kbs_register', 'kbs_profile_editor' );
 	$needs_bs4     = $post->ID == kbs_get_option( 'tickets_page' );
-    $needs_bs4     = false;
 
     if ( ! $needs_bs4 && ! empty( $post ) && is_a( $post, 'WP_Post' ) )	{
         foreach( $shortcodes as $shortcode )    {

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -276,8 +276,10 @@ function kbs_load_admin_scripts( $hook ) {
 		}
 	}
 
+    $singular = kbs_get_ticket_label_singular();
+
 	wp_localize_script( 'kbs-admin-scripts', 'kbs_vars', array(
-		'add_new_ticket'          => sprintf( __( 'Add New %s', 'kb-support' ), kbs_get_ticket_label_singular() ),
+		'add_new_ticket'          => sprintf( __( 'Add New %s', 'kb-support' ), $singular ),
 		'admin_url'               => admin_url(),
 		'ajax_loader'             => KBS_PLUGIN_URL . 'assets/images/loading.gif',
         'delete_reply_warn'       => __( "You will permanently delete this reply.\n\nDepending on configuration, your customer may have already received it via email.\n\nClick 'Cancel' to stop, 'OK' to delete.", 'kb-support' ),
@@ -295,10 +297,11 @@ function kbs_load_admin_scripts( $hook ) {
         'hide_submission'         => __( 'Hide submission data', 'kb-support' ),
 		'kbs_version'             => KBS_VERSION,
 		'new_media_ui'            => apply_filters( 'kbs_use_35_media_ui', 1 ),
+        'new_reply_notice'        => sprintf( __( 'A new reply has been added to this %s. Click OK to reload replies now, or Cancel to ignore.', 'kb-support' ), strtolower( $singular ) ),
 		'no_note_content'         => __( 'There is no content in your note', 'kb-support' ),
 		'no_ticket_reply_content' => __( 'There is no content in your reply', 'kb-support' ),
 		'note_not_added'          => __( 'Your note could not be added', 'kb-support' ),
-		'one_option'              => sprintf( __( 'Choose a %s', 'kb-support' ), kbs_get_ticket_label_singular() ),
+		'one_option'              => sprintf( __( 'Choose a %s', 'kb-support' ), $singular ),
 		'one_or_more_option'      => sprintf( __( 'Choose one or more %s', 'kb-support' ), kbs_get_ticket_label_plural() ),
 		'post_id'                 => isset( $post->ID ) ? $post->ID : null,
 		'post_type'               => isset( $_GET['post'] ) ? get_post_type( $_GET['post'] ) : false,
@@ -307,7 +310,7 @@ function kbs_load_admin_scripts( $hook ) {
         'send_closure_email'      => __( 'Send closure email?', 'kb-support' ),
 		'ticket_confirm_close'    => __( 'Are you sure you wish to close this ticket? Click OK to close, or Cancel to return.', 'kb-support' ),
 		'ticket_reply_added'      => 'ticket_reply_added',
-		'ticket_reply_failed'     => sprintf( __( 'Could not add %s Reply', 'kb-support' ), kbs_get_ticket_label_singular() ),
+		'ticket_reply_failed'     => sprintf( __( 'Could not add %s Reply', 'kb-support' ), $singular ),
 		'type_to_search'          => sprintf( __( 'Type to search %s', 'kb-support' ), kbs_get_article_label_plural() ),
         'view_reply'              => __( 'View Reply', 'kb-support' ),
 		'view_note'               => __( 'View Note', 'kb-support' ),

--- a/includes/tickets/ticket-actions.php
+++ b/includes/tickets/ticket-actions.php
@@ -503,3 +503,26 @@ function kbs_cleanup_after_deleting_ticket( $ticket_id = 0 )	{
 
 } // kbs_cleanup_after_deleting_ticket
 add_action( 'after_delete_post', 'kbs_cleanup_after_deleting_ticket' );
+
+/**
+ * Monitor for new ticket replies via the WordPress heartbeat.
+ *
+ * @since   1.2.8
+ * @param   array   $response   Heartbeat response data
+ * @param   array   $data       Data received (unslashed)
+ * @return  array   Heartbeat response data
+ */
+function kbs_monitor_heartbeat_for_new_ticket_replies( $response, $data )   {
+    if ( ! empty( $data['kbs_last_reply'] ) && ! empty( $data['kbs_ticket_id'] ) )   {
+        $last_reply   = $data['kbs_last_reply'];
+        $ticket_id    = $data['kbs_ticket_id'];
+        $latest_reply = kbs_get_last_reply( $ticket_id );
+
+        if ( $last_reply < $latest_reply->ID )  {
+            $response['has_new_reply'] = $latest_reply->ID;
+        }
+    }
+
+    return $response;
+} // kbs_monitor_heartbeat_for_new_ticket_replies
+add_filter( 'heartbeat_received', 'kbs_monitor_heartbeat_for_new_ticket_replies', 10, 2 );


### PR DESCRIPTION
Should a customer or ticket participant add a reply to a ticket whilst an agent is editing it, the agent will now be notified via a pop and given the opportunity to reload the replies onto the current screen